### PR TITLE
Reuse local test connections in testlib

### DIFF
--- a/server_tests/testlib.py
+++ b/server_tests/testlib.py
@@ -12,6 +12,31 @@ import os
 import http.client
 import re
 
+_sessions = {}
+_raw_connections = {}
+
+
+def get_session(port):
+    if port not in _sessions:
+        _sessions[port] = requests.Session()
+    return _sessions[port]
+
+
+def get_raw_connection(port):
+    if port not in _raw_connections:
+        _raw_connections[port] = http.client.HTTPConnection("localhost", port)
+    return _raw_connections[port]
+
+
+def wrap_raw_response(raw_response, port, route):
+    response = requests.Response()
+    response.status_code = raw_response.status
+    response.headers = requests.structures.CaseInsensitiveDict(raw_response.getheaders())
+    response._content = raw_response.read()
+    response.url = f"http://localhost:{port}{route}"
+    response.read = lambda: response.content
+    return response
+
 
 def localhost_get_request(port, route="", headers={}, benchmark=False, raw=False, method="GET"):
     global benchmarks, s
@@ -21,15 +46,19 @@ def localhost_get_request(port, route="", headers={}, benchmark=False, raw=False
     for attempt in range(3):
         try:
             if raw:
-                conn = http.client.HTTPConnection("localhost", port)
+                conn = get_raw_connection(port)
                 conn.request(method, route, headers=headers)
-                r = conn.getresponse()
+                raw_response = conn.getresponse()
+                r = wrap_raw_response(raw_response, port, route)
             else:
-                r = requests.get(
-                    f"http://localhost:{port}{route}", headers=headers)
+                r = get_session(port).get(f"http://localhost:{port}{route}", headers=headers)
             break  # Success, exit retry loop
         except Exception as e:
             print(f"Error (attempt {attempt + 1}/3): {e}")
+            if raw:
+                conn = _raw_connections.pop(port, None)
+                if conn is not None:
+                    conn.close()
             if attempt == 2:  # Last attempt
                 return None
             time.sleep(0.1)  # Brief delay before retry


### PR DESCRIPTION
This is needed because the test harness was opening a fresh HTTP connection for almost every request, and on Windows that made the user rate-limiting tests too slow.

Those tests depend on a rolling 60-second rate-limit window. With one new connection per request earlier requests started falling out of the window and many requests that should have been 429 stayed 200.

The fix reuses local connections centrally in testlib.py, so the tests send the same requests much faster without changing the server behavior.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Reused local HTTP sessions and raw connections to speed tests

**🔧 Refactors**
* Wrapped raw http.client responses and enhanced retry cleanup logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/105044097?groupId=6)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->