### PR TITLE
Add attack wave stats tester assertion

### DIFF
--- a/server_tests/test_wave_attack/start_config.json
+++ b/server_tests/test_wave_attack/start_config.json
@@ -1,4 +1,5 @@
 {
   "block": true,
+  "receivedAnyStats": false,
   "allowedIPAddresses": ["2.16.53.10"]
 }

--- a/server_tests/test_wave_attack/test.py
+++ b/server_tests/test_wave_attack/test.py
@@ -203,6 +203,51 @@ def check_wave_attack(collector, get_method_path, ip, user_id, len_samples):
                 isinstance(sample["url"], str), "Url is not a string")
 
 
+def check_attack_wave_stats(collector, start_heartbeat_events, expected_total):
+    max_wait_time = 130
+    deadline = time.time() + max_wait_time
+    new_heartbeats = []
+    total = 0
+    blocked = 0
+    found_attack_waves = False
+
+    while time.time() < deadline:
+        all_heartbeats = c.get_events("heartbeat")
+        new_heartbeats = all_heartbeats[len(start_heartbeat_events):]
+
+        total = 0
+        blocked = 0
+        found_attack_waves = False
+
+        for heartbeat in new_heartbeats:
+            attack_waves = heartbeat.get("stats", {}).get(
+                "requests", {}).get("attackWaves")
+            if not isinstance(attack_waves, dict):
+                continue
+
+            found_attack_waves = True
+            total += attack_waves.get("total", 0)
+            blocked += attack_waves.get("blocked", 0)
+
+        if total >= expected_total:
+            break
+
+        time.sleep(1)
+
+    collector.soft_assert(
+        len(new_heartbeats) >= 1,
+        f"Expected at least 1 heartbeat event with attack wave stats, got {len(new_heartbeats)}")
+    collector.soft_assert(
+        found_attack_waves,
+        f"Expected attackWaves in heartbeat request stats, got {json.dumps(new_heartbeats)}")
+    collector.soft_assert(
+        total == expected_total,
+        f"Expected attack wave stats total {expected_total}, got {total} from {json.dumps(new_heartbeats)}")
+    collector.soft_assert(
+        blocked == 0,
+        f"Expected attack wave stats blocked 0, got {blocked} from {json.dumps(new_heartbeats)}")
+
+
 def check_wave_attack_with_same_ip(collector, get_method_path, ip, user_id):
     start_events = c.get_events("detected_attack_wave")
     for i in range(16):
@@ -258,6 +303,8 @@ def check_wave_attack_with_bypass_ip(collector, ip, user_id):
 def run_test(s: TestServer, c: CoreApi):
     collector = AssertionCollector()
 
+    start_heartbeat_events = c.get_events("heartbeat")
+
     check_wave_attack(collector, get_random_path_filename,
                       "2.16.53.5", "1234", len(filenames))
     check_wave_attack(collector, get_random_path_directory,
@@ -266,6 +313,8 @@ def run_test(s: TestServer, c: CoreApi):
                       "1236", len(file_extensions))
     check_wave_attack(collector, get_random_path_query,
                       "2.16.53.8", "1237", len(queries))
+
+    check_attack_wave_stats(collector, start_heartbeat_events, 4)
 
     check_wave_attack_with_same_ip(collector,
                                    get_random_path_filename, "2.16.53.5", "1234")


### PR DESCRIPTION
## Summary
- assert attack wave detections are reported in heartbeat stats
- mark wave attack test config as not having received prior stats so startup heartbeats are emitted

## Checks
- python -m py_compile server_tests/test_wave_attack/test.py
- git diff --check